### PR TITLE
Fix batch existence endpoint naming

### DIFF
--- a/src/main/java/com/ai/api/controller/ReptileController.java
+++ b/src/main/java/com/ai/api/controller/ReptileController.java
@@ -77,13 +77,13 @@ public class ReptileController {
    * @return 返回信息
    */
   @SaIgnore
-  @PostMapping("/hasBath")
-  public Result<List<String>> hasReptileDataBath(@RequestBody List<String> urls) {
-    List<String> md5s1 = userDataService.listMd5();
+  @PostMapping("/hasBatch")
+  public Result<List<String>> hasReptileDataBatch(@RequestBody List<String> urls) {
+    List<String> existingMd5s = userDataService.listMd5();
     try {
       List<String> md5s =
           new java.util.ArrayList<>(urls.stream().map(url -> MD5.create().digestHex(url)).toList());
-      md5s.removeAll(md5s1);
+      md5s.removeAll(existingMd5s);
       return Result.success(md5s);
     } catch (Exception e) {
       return Result.error(501, "查询失败");


### PR DESCRIPTION
## Summary
- fix typo in reptile controller batch existence endpoint

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM – Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68443514d19083269b66c3a7b6db7e60